### PR TITLE
remove panics, implement server logging

### DIFF
--- a/internal/api/registry.go
+++ b/internal/api/registry.go
@@ -35,9 +35,9 @@ func GetPackage(hostname string, namespace string, pkg string, version string, o
 }
 
 type VersionsResponse struct {
+	Warnings interface{} `json:"warnings"`
 	Id       string      `json:"id"`
 	Versions []Version   `json:"versions"`
-	Warnings interface{} `json:"warnings"`
 }
 
 type Version struct {
@@ -62,11 +62,11 @@ type DownloadResponse struct {
 	Shasum              string   `json:"shasum"`
 	SigningKeys         struct {
 		GpgPublicKeys []struct {
+			SourceUrl      interface{} `json:"source_url"`
 			KeyId          string      `json:"key_id"`
 			AsciiArmor     string      `json:"ascii_armor"`
 			TrustSignature string      `json:"trust_signature"`
 			Source         string      `json:"source"`
-			SourceUrl      interface{} `json:"source_url"`
 		} `json:"gpg_public_keys"`
 	} `json:"signing_keys"`
 }

--- a/internal/hash/hash.go
+++ b/internal/hash/hash.go
@@ -3,11 +3,12 @@ package hash
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"golang.org/x/mod/sumdb/dirhash"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+
+	"golang.org/x/mod/sumdb/dirhash"
 )
 
 func GetHashes(downloadUrl string) ([]string, error) {
@@ -26,24 +27,36 @@ func downloadAndHash(url string) ([]string, error) {
 	}
 	defer out.Close()
 	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
 	defer resp.Body.Close()
+
 	_, err = io.Copy(out, resp.Body)
 	if err != nil {
 		return nil, err
 	}
+
 	hashes := []string{}
 	hash, err := dirhash.HashZip(out.Name(), dirhash.Hash1)
+	if err != nil {
+		return nil, err
+	}
+
 	hashes = append(hashes, hash)
 	f, err := os.Open(out.Name())
 	if err != nil {
 		return nil, err
 	}
+
 	defer f.Close()
 	hasher := sha256.New()
 	if _, err := io.Copy(hasher, f); err != nil {
 		return nil, err
 	}
+
 	hash = hex.EncodeToString(hasher.Sum(nil))
 	hashes = append(hashes, "zh:"+hash)
+
 	return hashes, nil
 }

--- a/internal/server/logger.go
+++ b/internal/server/logger.go
@@ -1,0 +1,21 @@
+package server
+
+import (
+	"fmt"
+	"io"
+	"runtime"
+)
+
+type logger struct {
+	writer io.Writer
+}
+
+func (l logger) warn(msg string) {
+	_, filename, line, _ := runtime.Caller(1)
+	_, _ = l.writer.Write([]byte(fmt.Sprintf("[WARN] %s:%d %s\n", filename, line, msg)))
+}
+
+func (l logger) error(msg string) {
+	_, filename, line, _ := runtime.Caller(1)
+	_, _ = l.writer.Write([]byte(fmt.Sprintf("[ERROR] %s:%d %s\n", filename, line, msg)))
+}


### PR DESCRIPTION
Rather than panic, I think the app should log appropriately and return 500's to consumers. This makes any issues encountered more informative to consumers.

I also made a couple of fixes as suggested by golangci-lint such as properly defer'ing response body closures and realigning struct fields using [fieldalignment](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/fieldalignment) to reduce memory consumption.